### PR TITLE
Use CPPFLAGS in the Makefile (closes #43)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 .POSIX:
-CC      = cc
-CFLAGS  = -std=c99 -Wall -Wextra -Wno-missing-field-initializers -Os
-LDFLAGS = -ggdb3
-LDLIBS  =
-PREFIX  = /usr/local
+CC       = cc
+CFLAGS   = -std=c99 -Wall -Wextra -Wno-missing-field-initializers -Os
+CPPFLAGS =
+LDFLAGS  = -ggdb3
+LDLIBS   =
+PREFIX   = /usr/local
 
 all: endlessh
 
 endlessh: endlessh.c
-	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ endlessh.c $(LDLIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ endlessh.c $(LDLIBS)
 
 install: endlessh
 	install -d $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Debian uses CPPFLAGS to pass arguments like -D_FORTIFY_SOURCE=2.